### PR TITLE
Support Windows

### DIFF
--- a/conf/conf.py
+++ b/conf/conf.py
@@ -5,29 +5,34 @@
     the app version
 """
 
+import tempfile
+from pathlib import Path
+
 # Current Version
 CURRENT_VERSION = "1.8.8"
 
 #  Some file references
 
+p = Path(tempfile.gettempdir())
+
 #  Report Info
-INVENTORY_FILE = "/tmp/inventory_report.csv"
-SWATCH_FILE = "/tmp/swatch_report.csv"
-MATCH_FILE = "/tmp/match_inv_sw.csv"
-ISSUE_SUMMARY = "/tmp/issue_summary.log"
-PATCH_SYSTEMS_FILE = "/tmp/patch_systems.csv"
-VULNERABILITY_SYSTEMS_FILE = "/tmp/vulnerability_systems.csv"
-ADVISOR_FILE = "/tmp/advisor_systems.csv"
+INVENTORY_FILE = (p / "inventory_report.csv").resolve()
+SWATCH_FILE = (p / "swatch_report.csv").resolve()
+MATCH_FILE = (p / "match_inv_sw.csv").resolve()
+ISSUE_SUMMARY = (p / "issue_summary.log").resolve()
+PATCH_SYSTEMS_FILE = (p / "patch_systems.csv").resolve()
+VULNERABILITY_SYSTEMS_FILE = (p / "vulnerability_systems.csv").resolve()
+ADVISOR_FILE = (p / "advisor_systems.csv").resolve()
 
 # TS Info
-INV_JSON_FILE = "/tmp/inventory.json"
-SW_JSON_FILE = "/tmp/swatch.json"
-MATCH_FILE = "/tmp/match_inv_sw.csv"
-PATCH_JSON_FILE = "/tmp/patch.json"
-VULNERABILITY_JSON_FILE = "/tmp/vulnerability.json"
-ADVISOR_JSON_FILE = "/tmp/advisor.json"
+INV_JSON_FILE = (p / "inventory.json").resolve()
+SW_JSON_FILE = (p /"swatch.json").resolve()
+MATCH_FILE = (p / "match_inv_sw.csv").resolve()
+PATCH_JSON_FILE = (p / "patch.json").resolve()
+VULNERABILITY_JSON_FILE = (p / "vulnerability.json").resolve()
+ADVISOR_JSON_FILE = (p / "advisor.json").resolve()
 
-TGZ_FILE = "/tmp/crhc_data.tgz"
+TGZ_FILE = (p / "crhc_data.tgz").resolve()
 
 
 # App conf file

--- a/credential/token.py
+++ b/credential/token.py
@@ -10,6 +10,8 @@ import sys
 import datetime
 import jwt
 import requests
+from time import time as timetime
+
 
 # Conf file used to store the access_key and some additional information
 CONF_FILE = "/.crhc.conf"
@@ -77,8 +79,7 @@ def get_token():
     try:
         # Using jwt to collect some information from the local token file
         exp_date_from_token = jwt.decode(access_token, options={"verify_signature": False})['exp']
-        current_time = datetime.datetime.now()
-        current_time_epoch = int(current_time.strftime('%s'))
+        current_time_epoch = int(timetime())
 
         # Conditional to check if the token is expired. In case of affirmative, the same
         # will be refreshed.

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -5,11 +5,15 @@
 """
 import json
 import csv
+import tempfile
+from pathlib import Path
 from report import report
 
 
 INPUT_JSON = "tests/data/inventory.json"
-OUTPUT_CSV = "/tmp/inventory_report.csv"
+
+p = Path(tempfile.gettempdir())
+OUTPUT_CSV = (p / "inventory_report.csv").resolve()
 
 
 def calling_csv_report_inventory():


### PR DESCRIPTION
This PR adds support for Windows and adds support to run the test script on forks.

@waldirio Question: why are CSV files written to a temporary directory? In fact, why are CSV files written at all by default? JSON output is by default to stdout, shouldn't CSV output be to stdout too, and then have a '-o / --output' parameter to tell crhc-cli I want to write the output (be it JSON o CSV) to a file? That way, we could get rid of the temporary directory.