### PR TITLE
Fixed ansible issue with max items in request

### DIFF
--- a/conf/conf.py
+++ b/conf/conf.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 
 # Current Version
-CURRENT_VERSION = "1.16.16"
+CURRENT_VERSION = "1.15.15"
 
 #  Some file references
 

--- a/conf/conf.py
+++ b/conf/conf.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 
 # Current Version
-CURRENT_VERSION = "1.15.15"
+CURRENT_VERSION = "1.16.16"
 
 #  Some file references
 
@@ -48,3 +48,5 @@ TIME_TO_CHECK_THE_NEW_VERSION = 21600
 
 # Items per page when doing the API call
 ITEMS_PER_PAGE = 50
+# Ansible has a max limit of 25 Items per page when doing the API call
+ANSIBLE_ITEMS_PER_PAGE = 25

--- a/execution/execution.py
+++ b/execution/execution.py
@@ -997,11 +997,11 @@ def get_ansible_unique_hosts():
     for page in range(0, num_of_pages):
         url = (
             "https://console.redhat.com/api/tower-analytics/v1/host_explorer/?sort_by=host_count&limit="
-            + str(conf.ITEMS_PER_PAGE)
+            + str(conf.ANSIBLE_ITEMS_PER_PAGE)
             + "&offset="
             + str(count)
         )
-        count = count + conf.ITEMS_PER_PAGE
+        count = count + conf.ANSIBLE_ITEMS_PER_PAGE
         response = connection_request_post(url, request_data)
 
         responseJson = response.json()


### PR DESCRIPTION
Ansible API was failing because were requesting 50 ietms at a time, and the API has changed to only allow 25.

Have added a new conf value to manage this, and updated the version.